### PR TITLE
Change sys.print() to console.log()

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -29,7 +29,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 */
 
 var path = require('path'),
-    sys  = require('sys'),
+    sys  = require('util'),
     fs   = require('fs');
 
 var makeArray = function(nonarray) { 

--- a/logger.js
+++ b/logger.js
@@ -40,7 +40,7 @@ var makeArray = function(nonarray) {
 // if `log_file_path` is null, log to STDOUT.
 var Logger = function(log_file_path) {
   // default write is STDOUT
-  this.write     = sys.print;
+  this.write     = console.log;
   this.log_level_index = 3;
   
   // if a path is given, try to write to it


### PR DESCRIPTION
Addresses `sys.print` deprecation warning generated on node.js versions > 0.12.