### PR TITLE
Removed require('sys') in favor of require('util') as sys is deprecated

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -29,11 +29,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 */
 
 var path = require('path'),
-    sys  = require('sys'),
+    sys  = require('util'),
     fs   = require('fs');
 
 var makeArray = function(nonarray) { 
-  return Array.prototype.slice.call(nonarray); 
+  return Array.prototype.slice.call(nonarray);
 };
 
 // Create a new instance of Logger, logging to the file at `log_file_path`


### PR DESCRIPTION
Sys was deprecated in node. Replaced the require('sys') with require('util') to avoid deprecation warnings when using this package inside of another application.