### PR TITLE
sys-to-util

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -29,7 +29,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 */
 
 var path = require('path'),
-    sys  = require('sys'),
+    sys  = require('util'),
     fs   = require('fs');
 
 var makeArray = function(nonarray) { 


### PR DESCRIPTION
line 32 of logger.js required 'sys', which is deprecated. Updated to require 'util'.